### PR TITLE
Fix typo in the help message

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -14,7 +14,15 @@ pub enum Platform {
 
     #[value(name = "openbsd")]
     #[cfg_attr(target_os = "openbsd", default)]
-    OpenBsd,
+    OpenBSD,
+
+    #[value(name = "freebsd")]
+    #[cfg_attr(target_os = "freebsd", default)]
+    FreeBSD,
+
+    #[value(name = "netbsd")]
+    #[cfg_attr(target_os = "netbsd", default)]
+    NetBSD,
 
     #[cfg_attr(target_os = "windows", default)]
     Windows,
@@ -23,13 +31,15 @@ pub enum Platform {
     Android,
 
     #[value(name = "sunos")]
-    SunOs,
+    SunOS,
 
     #[cfg_attr(
         not(any(
             target_os = "linux",
             target_os = "macos",
             target_os = "openbsd",
+            target_os = "freebsd",
+            target_os = "netbsd",
             target_os = "windows",
             target_os = "android"
         )),
@@ -40,24 +50,30 @@ pub enum Platform {
 
 impl Platform {
     pub fn iterator() -> impl Iterator<Item = Platform> {
-        use self::Platform::{Android, Linux, OpenBsd, OsX, SunOs, Windows};
-        [Linux, OsX, OpenBsd, Windows, Android, SunOs].into_iter()
+        use self::Platform::{Android, FreeBSD, Linux, NetBSD, OpenBSD, OsX, SunOS, Windows};
+        [
+            Android, FreeBSD, Linux, NetBSD, OpenBSD, OsX, SunOS, Windows,
+        ]
+        .iter()
+        .copied()
     }
 }
 
 // These are the directory names.
 impl Display for Platform {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Linux => "linux",
-            Self::OsX => "osx",
-            Self::OpenBsd => "openbsd",
-            Self::Windows => "windows",
+        let platform_str = match self {
             Self::Android => "android",
-            Self::SunOs => "sunos",
             Self::Common => "common",
-        }
-        .fmt(f)
+            Self::FreeBSD => "freebsd",
+            Self::Linux => "linux",
+            Self::NetBSD => "netbsd",
+            Self::OsX => "osx",
+            Self::OpenBSD => "openbsd",
+            Self::SunOS => "sunos",
+            Self::Windows => "windows",
+        };
+        write!(f, "{platform_str}")
     }
 }
 
@@ -142,7 +158,7 @@ pub struct Cli {
     #[arg(long)]
     pub no_raw: bool,
 
-    /// Supress status messages.
+    /// Suppress status messages.
     #[arg(short, long)]
     pub quiet: bool,
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -351,6 +351,8 @@ impl<'a> Cache<'a> {
             .into_iter()
             .chain(self.list_dir("osx", &lang_dir)?)
             .chain(self.list_dir("openbsd", &lang_dir)?)
+            .chain(self.list_dir("freebsd", &lang_dir)?)
+            .chain(self.list_dir("netbsd", &lang_dir)?)
             .chain(self.list_dir("windows", &lang_dir)?)
             .chain(self.list_dir("android", &lang_dir)?)
             .chain(self.list_dir("sunos", &lang_dir)?)


### PR DESCRIPTION
## Changes

- Add support for the newly added FreeBSD and NetBSD Platforms.
- Update Capitalization for these platforms in Code.
- Minor fixes.

## Reference image

![image](https://github.com/tldr-pages/tlrc/assets/26346867/be1ac9de-5c7c-4b7b-8f7e-62607c756019)

## Reference output

```zsh
➜  debug git:(feat/bsd) ./tldr
tlrc v1.6.0 (implementing the tldr client specification v2.0) - debug build (2323da0)
A tldr client written in Rust

Usage: tldr [OPTIONS] <PAGE>...

Arguments:
  <PAGE>...  The tldr page to show

Options:
  -u, --update               Update the cache
  -l, --list                 List all pages in the current platform
  -a, --list-all             List all pages
  -i, --info                 Show cache information (installed languages and the number of pages)
  -r, --render <FILE>        Render the specified markdown file
      --clean-cache          Clean the cache
      --gen-config           Print the default config
      --config-path          Print the default config path and create the config directory
  -p, --platform <PLATFORM>  Specify the platform to use [default: linux] [possible values: linux, osx, openbsd, freebsd, netbsd, windows, android, sunos, common]
  -L, --language <LANGUAGE>  Specify the languages to use
  -o, --offline              Do not update the cache, even if it is stale
  -c, --compact              Strip empty lines from output
      --no-compact           Do not strip empty lines from output (overrides --compact)
  -R, --raw                  Print pages in raw markdown instead of rendering them
      --no-raw               Render pages instead of printing raw file contents (overrides --raw)
  -q, --quiet                Suppress status messages
      --color <WHEN>         Specify when to enable color [default: auto] [possible values: auto, always, never]
      --config <FILE>        Specify an alternative path to the config file
  -v, --version              Print version
  -h, --help                 Print help

See 'man tldr' or https://tldr.sh/tlrc for more information.
```
