### PR TITLE
README: fix configuration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ tldr --config-path
 To generate a default config file, run:
 
 ```shell
-tldr --gen-config > $(tldr --config-path)
+tldr --gen-config > "$(tldr --config-path)"
 ```
 
 or copy the below example.


### PR DESCRIPTION
Small configuration guide fix when config path includes spaces in it - which is often the case on osx